### PR TITLE
bug fix

### DIFF
--- a/drawview/src/main/java/com/byox/drawview/views/DrawView.java
+++ b/drawview/src/main/java/com/byox/drawview/views/DrawView.java
@@ -180,7 +180,7 @@ public class DrawView extends FrameLayout implements View.OnTouchListener {
                 if (onDrawViewListener != null)
                     onDrawViewListener.onStartDrawing();
 
-                if (mDrawMoveHistoryIndex != -1 &&
+                if (mDrawMoveHistoryIndex >= -1 &&
                         mDrawMoveHistoryIndex < mDrawMoveHistory.size() - 1)
                     mDrawMoveHistory = mDrawMoveHistory.subList(0, mDrawMoveHistoryIndex + 1);
 


### PR DESCRIPTION
when undo mDrawMoveHistoryIndex to -1 , and then draw ,the first item of mDrawMoveHistory will appear in drawView.