### PR TITLE
IOException error fix

### DIFF
--- a/drawview/src/main/java/com/byox/drawview/dictionaries/DrawMove.java
+++ b/drawview/src/main/java/com/byox/drawview/dictionaries/DrawMove.java
@@ -1,9 +1,12 @@
 package com.byox.drawview.dictionaries;
 
+import android.annotation.SuppressLint;
 import android.graphics.Bitmap;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Path;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 import com.byox.drawview.enums.BackgroundScale;
 import com.byox.drawview.enums.BackgroundType;
@@ -25,7 +28,8 @@ import java.util.List;
  * @author Ing. Oscar G. Medina Cruz
  */
 
-public class DrawMove implements Serializable {
+@SuppressLint("ParcelCreator")
+public class DrawMove implements Serializable , Parcelable {
 
     private static DrawMove mSingleton;
 
@@ -165,5 +169,14 @@ public class DrawMove implements Serializable {
             mSingleton.mBackgroundMatrix = backgroundMatrix;
             return mSingleton;
         } else throw new RuntimeException("Create new instance of DrawMove first!");
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
     }
 }


### PR DESCRIPTION
After setting a background image, when i pressed the device home button, IOException error occurs.
so i fixed it.

**Error Details :**
   java.lang.RuntimeException: Parcelable encountered IOException writing serializable object (name = com.byox.drawview.dictionaries.DrawMove)
        at android.os.Parcel.writeSerializable(Parcel.java:1786)
        at android.os.Parcel.writeValue(Parcel.java:1734)
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:801)
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1506)
        at android.os.Bundle.writeToParcel(Bundle.java:1181)
        at android.os.Parcel.writeBundle(Parcel.java:841)
        at android.os.Parcel.writeValue(Parcel.java:1652)
        at android.os.Parcel.writeSparseArray(Parcel.java:929)
        at android.os.Parcel.writeValue(Parcel.java:1686)
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:801)
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1506)
        at android.os.Bundle.writeToParcel(Bundle.java:1181)
        at android.os.Parcel.writeBundle(Parcel.java:841)
        at android.os.Parcel.writeValue(Parcel.java:1652)
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:801)
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1506)
        at android.os.Bundle.writeToParcel(Bundle.java:1181)
        at android.app.IActivityManager$Stub$Proxy.activityStopped(IActivityManager.java:5166)
        at android.app.ActivityThread$StopInfo.run(ActivityThread.java:4148)
        at android.os.Handler.handleCallback(Handler.java:789)
        at android.os.Handler.dispatchMessage(Handler.java:98)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:6944)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:327)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1374)
     Caused by: java.io.NotSerializableException: android.graphics.Matrix
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1233)
        at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1597)
        at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1558)
        at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1481)
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1227)
        at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:347)
        at android.os.Parcel.writeSerializable(Parcel.java:1781)