### PR TITLE
changed behavior of text input

### DIFF
--- a/drawview/src/main/java/com/byox/drawview/views/DrawView.java
+++ b/drawview/src/main/java/com/byox/drawview/views/DrawView.java
@@ -370,7 +370,7 @@ public class DrawView extends FrameLayout implements View.OnTouchListener {
                 case MotionEvent.ACTION_UP:
                     lastMoveIndex = mDrawMoveHistory.size() - 1;
 
-                    if (mLastTouchEvent == MotionEvent.ACTION_DOWN) {
+                    if (mLastTouchEvent == MotionEvent.ACTION_DOWN && mDrawingMode != DrawingMode.TEXT) {
                         if (mDrawMoveHistory.size() > 0) {
                             mDrawMoveHistory.remove(lastMoveIndex);
                             mDrawMoveHistoryIndex--;


### PR DESCRIPTION
Text input is subject to the cancellation exception when only pressed down without dragging.
The behavior of canceling the input when only pressing down on arrows or other shapes is intuitive, but not at all intuitive for text input.